### PR TITLE
Add dynamic project sitemap and enhance project page SEO with JSON-LD

### DIFF
--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -3,6 +3,7 @@ import ProjectLinks from "../components/ProjectLinks";
 import { Metadata } from "next";
 import Description from "./components/Description";
 import Image from "next/image";
+import { notFound } from "next/navigation";
 
 interface ProjectType {
   thumbnail: string;
@@ -32,11 +33,46 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { slug } = await params;
   const response = await fetch(`${process.env.BASE_URL}/api/projects/${slug}`);
+
+  if (!response.ok) {
+    return {
+      title: "Project Not Found",
+      robots: {
+        index: false,
+        follow: false,
+      },
+    };
+  }
+
   const project = await response.json();
+  const projectUrl = `${process.env.BASE_URL}/projects/${slug}`;
 
   return {
     title: project.title,
     description: project.description,
+    alternates: {
+      canonical: projectUrl,
+    },
+    openGraph: {
+      title: project.title,
+      description: project.description,
+      url: projectUrl,
+      type: "article",
+      images: project.thumbnail
+        ? [
+            {
+              url: project.thumbnail,
+              alt: `${project.title} preview image`,
+            },
+          ]
+        : [],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: project.title,
+      description: project.description,
+      images: project.thumbnail ? [project.thumbnail] : [],
+    },
   };
 }
 
@@ -48,9 +84,29 @@ export default async function Project({
   const { slug } = await params;
 
   const response = await fetch(`${process.env.BASE_URL}/api/projects/${slug}`);
+
+  if (!response.ok) {
+    notFound();
+  }
+
   const project = await response.json();
+  const schema = {
+    "@context": "https://schema.org",
+    "@type": "CreativeWork",
+    name: project.title,
+    description: project.description,
+    image: project.thumbnail,
+    datePublished: project.created_at,
+    url: `${process.env.BASE_URL}/projects/${slug}`,
+    keywords: [...(project.category ?? []), ...(project.stack ?? [])],
+  };
+
   return (
     <div>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+      />
       <Container className="text-[#393a1f] dark:text-white">
         <div>
           <header>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -2,6 +2,23 @@ import { MetadataRoute } from "next";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const lastModified = new Date().toISOString();
+  const projectsResponse = await fetch(`${process.env.BASE_URL}/api/projects`, {
+    next: { revalidate: 3600 },
+  });
+
+  const projects = projectsResponse.ok
+    ? ((await projectsResponse.json()) as { id: string; created_at?: string }[])
+    : [];
+
+  const projectPages = projects
+    .filter(({ id }) => Boolean(id))
+    .map(({ id, created_at }) => ({
+      url: `${process.env.BASE_URL}/projects/${id}`,
+      lastModified: created_at ?? lastModified,
+      changeFrequency: "monthly" as const,
+      priority: 0.7,
+    }));
+
   return [
     {
       url: `${process.env.BASE_URL}`,
@@ -15,5 +32,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: "monthly",
       priority: 0.8,
     },
+    ...projectPages,
   ];
 }


### PR DESCRIPTION
### Motivation
- Improve search engine discoverability by surfacing individual project pages in the sitemap.
- Provide richer metadata and social previews for project detail pages so shared links render well on platforms and in SERPs.
- Avoid indexing missing or broken project pages and supply structured data to help search engines understand project content.

### Description
- Add dynamic sitemap generation in `src/app/sitemap.ts` by fetching `/api/projects`, mapping project IDs to `/projects/[id]` entries, and appending them to the sitemap with sensible `lastModified`, `changeFrequency`, and `priority` values.
- Enhance `generateMetadata` in `src/app/projects/[slug]/page.tsx` to return `alternates.canonical`, Open Graph fields, and Twitter card fields when a project is found, and return `noindex, nofollow` metadata when the project API responds non-OK.
- Add runtime defensive behavior in the page component to call `notFound()` for non-OK project fetches to prevent rendering and indexing invalid pages.
- Inject JSON-LD `CreativeWork` structured data into the project page markup to surface title, description, image, publish date, URL, and keywords.

### Testing
- Ran `npm run lint`, which failed in this environment due to `next lint` resolving to an invalid project directory (`Invalid project directory provided, no such directory: /workspace/S-P-M/lint`).
- Ran `npm run build`, which failed because the build could not fetch Google Fonts (Rubik) in this environment causing a Turbopack error (`Failed to fetch Rubik from Google Fonts`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dcae3b1148320a5eee523e7dd230e)